### PR TITLE
Compiles on macOS now.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -14,7 +14,7 @@
 
 
 // Approximations of some Windows functions to ease portability
-#if defined __GNU_LIBRARY__ || defined __GLIBC__
+#if defined __GNU_LIBRARY__ || defined __GLIBC__ || defined __APPLE__
 static int min(int l, int r) { return l < r ? l : r; }
 static void strcat_s(char * dest, int size, char * str) {
     unsigned int dlen = strlen(dest);


### PR DESCRIPTION
The workaround for fopen_s, strcat_s, etc. was already in place, it just needed `|| defined __APPLE__` to make it compile on macOS.
