### PR TITLE
Fix a 43-year old bug in reciter where the unvoiced affricate/non-palate prefix doesn't correctly handle the 2-letter cases.

### DIFF
--- a/src/reciter.c
+++ b/src/reciter.c
@@ -210,9 +210,11 @@ pos36700:
                 
             case '@':
                 if(!Code37055(mem59-1,4)) { 
-                    A = inputtemp[X];
-                    if (A != 72) r = 1;
-                    if ((A != 84) && (A != 67) && (A != 83)) r = 1;
+                    if (inputtemp[X] != 'H') r = 1;
+                    else {
+                        A = inputtemp[--X];
+                        if ((A != 'T') && (A != 'C') && (A != 'S')) r = 1;
+                    }
                 }
                 break;
             case '+':


### PR DESCRIPTION
Fix a 43-year old bug in reciter where the unvoiced affricate/non-palate prefix doesn't correctly handle the 2-letter cases.
In the original 6502 code, there is a missing `DEX` opcode and a missing `LDA $8d00, X` opcode to load the previous letter into the accumulator, so the 2-letter test case will always fail as it compares the same letter both to `H`, and then later to `C`, `T`, and `S`.
This means the rule `@(UR)#=UH4R` will not correctly trigger on segments with the two letter prefices `CH` `TH` and `SH`, which is incorrect according to the NRL Report 7948 that the reciter rule set is based on.
This fixes words like 'thurible', 'shuriken', and 'ashura' (and likely others) where without this fix they will be incorrectly pronounced as 'thyurible' 'shyuriken' and 'ashyura'.